### PR TITLE
Fix and organize OpenAPI schema

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.74.0"
+channel = "1.83.0"
 

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -38,12 +38,13 @@ pub struct SignInResponse {
 
 #[utoipa::path(
     post,
-    path = "/v1/api/signin",
+    path = "/api/v1/signin",
+    tag = "Authentication",
     request_body = SignInBody,
     responses(
-        (status = 200, description = "User signed in successfully", body = SignInResponse),
-        (status = 500, description = "Internal server error"),
-        (status = 401, description = "Unauthorized user"),
+        (status = 201, description = "User signed in successfully", body = SignInResponse),
+        (status = 500, description = "Internal server error", body = ResponseError),
+        (status = 401, description = "Unauthorized user", body = ResponseError),
     )
 )]
 #[debug_handler]

--- a/src/server/block_handlers.rs
+++ b/src/server/block_handlers.rs
@@ -13,7 +13,7 @@ use crate::server::{
     config::AppState,
     db::DB,
     models::Block,
-    response::{ResponseError, ResponseResult},
+    response::{ResponseError, ResponseResult, BlockUploadedResponse},
 };
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -36,7 +36,7 @@ pub struct UploadBlockParams {
     post,
     path = "/api/v1/block",
     tag = "Block Management",
-    request_body(content = Vec<u8>, description = "Block data to upload", content_type = "application/octet-stream"),
+    request_body(content = [u8], description = "Block data to upload", content_type = "application/octet-stream"),
     params(
         ("file_hash" = String, Query, description = "File hash associated with the block"),
         ("idx" = u64, Query, description = "Block index within the file")
@@ -96,7 +96,7 @@ pub async fn upload_block_handler(
     path = "/api/v1/block/{hash}",
     tag = "Block Management",
     responses(
-        (status = 200, description = "Block found", body = Vec<u8>, content_type = "application/octet-stream"),
+        (status = 200, description = "Block found", body = [u8], content_type = "application/octet-stream"),
         (status = 404, description = "Block not found", body = ResponseError),
         (status = 500, description = "Internal server error", body = ResponseError),
     ),

--- a/src/server/block_handlers.rs
+++ b/src/server/block_handlers.rs
@@ -46,6 +46,9 @@ pub struct UploadBlockParams {
         (status = 201, description = "Block created successfully", body = ResponseResult),
         (status = 400, description = "Bad request", body = ResponseError),
         (status = 500, description = "Internal server error", body = ResponseError),
+    ),
+    security(
+        ("bearerAuth" = [])
     )
 )]
 #[debug_handler]
@@ -314,6 +317,7 @@ pub struct ListBlocksResponse {
 #[utoipa::path(
     get,
     path = "/api/v1/blocks",
+    tag = "Block Management",
     params(
         ("page" = Option<u32>, Query, description = "Page number (1-indexed)"),
         ("per_page" = Option<u32>, Query, description = "Number of items per page")
@@ -364,6 +368,7 @@ pub struct UserBlocksResponse {
 #[utoipa::path(
     get,
     path = "/api/v1/user/blocks",
+    tag = "Block Management",
     params(
         ("page" = Option<u32>, Query, description = "Page number (1-indexed)"),
         ("per_page" = Option<u32>, Query, description = "Number of items per page")
@@ -372,6 +377,9 @@ pub struct UserBlocksResponse {
         (status = 200, description = "Blocks found", body = UserBlocksResponse),
         (status = 401, description = "Unauthorized"),
         (status = 500, description = "Internal server error"),
+    ),
+    security(
+        ("bearerAuth" = [])
     )
 )]
 #[debug_handler]
@@ -428,6 +436,7 @@ pub struct BlockDownloadsResponse {
 #[utoipa::path(
     get,
     path = "/api/v1/block/{hash}/downloads",
+    tag = "Block Management",
     responses(
         (status = 200, description = "Download count retrieved successfully", body = BlockDownloadsResponse),
         (status = 404, description = "Block not found"),

--- a/src/server/block_handlers.rs
+++ b/src/server/block_handlers.rs
@@ -16,17 +16,9 @@ use crate::server::{
     response::{ResponseError, ResponseResult},
 };
 use serde::{Deserialize, Serialize};
-use utoipa::{OpenApi, ToSchema};
+use utoipa::ToSchema;
 
-#[derive(OpenApi)]
-#[openapi(
-    paths(upload_block_handler, get_block_handler, check_block_handler, verify_blocks_handler, get_blocks_by_hash_handler, list_blocks_handler, get_user_blocks_handler, get_block_downloads_handler),
-    components(schemas(Block, VerifyBlocksRequest, VerifyBlocksResponse, BlocksResponse, ListBlocksParams, ListBlocksResponse, UserBlocksResponse, BlockDownloadsResponse)),
-    tags(
-        (name = "blocks", description = "Block management API")
-    )
-)]
-pub struct BlockApi;
+// Block API endpoints are included in the main FlistApi in handlers.rs
 
 /// Query parameters for uploading a block
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
@@ -43,16 +35,17 @@ pub struct UploadBlockParams {
 #[utoipa::path(
     post,
     path = "/api/v1/block",
+    tag = "Block Management",
     request_body(content = Vec<u8>, description = "Block data to upload", content_type = "application/octet-stream"),
     params(
         ("file_hash" = String, Query, description = "File hash associated with the block"),
         ("idx" = u64, Query, description = "Block index within the file")
     ),
     responses(
-        (status = 200, description = "Block already exists", body = String),
-        (status = 201, description = "Block created successfully", body = String),
-        (status = 400, description = "Bad request"),
-        (status = 500, description = "Internal server error"),
+        (status = 200, description = "Block already exists", body = ResponseResult),
+        (status = 201, description = "Block created successfully", body = ResponseResult),
+        (status = 400, description = "Bad request", body = ResponseError),
+        (status = 500, description = "Internal server error", body = ResponseError),
     )
 )]
 #[debug_handler]
@@ -98,10 +91,11 @@ pub async fn upload_block_handler(
 #[utoipa::path(
     get,
     path = "/api/v1/block/{hash}",
+    tag = "Block Management",
     responses(
-        (status = 200, description = "Block found", content_type = "application/octet-stream"),
-        (status = 404, description = "Block not found"),
-        (status = 500, description = "Internal server error"),
+        (status = 200, description = "Block found", body = Vec<u8>, content_type = "application/octet-stream"),
+        (status = 404, description = "Block not found", body = ResponseError),
+        (status = 500, description = "Internal server error", body = ResponseError),
     ),
     params(
         ("hash" = String, Path, description = "Block hash")
@@ -136,9 +130,10 @@ pub async fn get_block_handler(
 #[utoipa::path(
     head,
     path = "/api/v1/block/{hash}",
+    tag = "Block Management",
     responses(
         (status = 200, description = "Block found"),
-        (status = 404, description = "Block not found"),
+        (status = 404, description = "Block not found", body = ResponseError),
     ),
     params(
         ("hash" = String, Path, description = "Block hash")
@@ -194,11 +189,12 @@ pub struct VerifyBlocksResponse {
 #[utoipa::path(
     post,
     path = "/api/v1/block/verify",
+    tag = "Block Management",
     request_body(content = VerifyBlocksRequest, description = "List of block hashes to verify", content_type = "application/json"),
     responses(
         (status = 200, description = "Verification completed", body = VerifyBlocksResponse),
-        (status = 400, description = "Bad request"),
-        (status = 500, description = "Internal server error"),
+        (status = 400, description = "Bad request", body = ResponseError),
+        (status = 500, description = "Internal server error", body = ResponseError),
     )
 )]
 #[debug_handler]
@@ -241,10 +237,11 @@ pub struct BlocksResponse {
 #[utoipa::path(
     get,
     path = "/api/v1/blocks/{hash}",
+    tag = "Block Management",
     responses(
         (status = 200, description = "Blocks found", body = BlocksResponse),
-        (status = 404, description = "Hash not found"),
-        (status = 500, description = "Internal server error"),
+        (status = 404, description = "Hash not found", body = ResponseError),
+        (status = 500, description = "Internal server error", body = ResponseError),
     ),
     params(
         ("hash" = String, Path, description = "File hash or block hash")

--- a/src/server/block_handlers.rs
+++ b/src/server/block_handlers.rs
@@ -236,6 +236,15 @@ pub struct BlockInfo {
     pub index: u64,
 }
 
+/// Block information with hash and size
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct UserBlockInfo {
+    /// Block hash
+    pub hash: String,
+    /// Block size in bytes
+    pub size: u64,
+}
+
 /// Response for blocks by hash endpoint
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct BlocksResponse {
@@ -368,8 +377,8 @@ pub async fn list_blocks_handler(
 /// Response for user blocks endpoint
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct UserBlocksResponse {
-    /// List of blocks with their indices
-    pub blocks: Vec<BlockInfo>,
+    /// List of blocks with their sizes
+    pub blocks: Vec<UserBlockInfo>,
     /// Total number of blocks
     pub total: u64,
     /// Total number of all blocks
@@ -421,7 +430,7 @@ pub async fn get_user_blocks_handler(
             let total = blocks.len() as u64;
             let response = UserBlocksResponse {
                 blocks: blocks.into_iter()
-                .map(|(hash, index)| BlockInfo { hash, index })
+                .map(|(hash, size)| UserBlockInfo { hash, size })
                 .collect(),
                 total,
                 all_blocks,

--- a/src/server/file_handlers.rs
+++ b/src/server/file_handlers.rs
@@ -31,7 +31,7 @@ pub struct FileUploadResponse {
     post,
     path = "/api/v1/file",
     tag = "File Management",
-    request_body(content = Vec<u8>, description = "File data to upload", content_type = "application/octet-stream"),
+    request_body(content = [u8], description = "File data to upload", content_type = "application/octet-stream"),
     responses(
         (status = 201, description = "File uploaded successfully", body = FileUploadResponse),
         (status = 400, description = "Bad request", body = ResponseError),
@@ -121,7 +121,7 @@ pub struct FileDownloadRequest {
     tag = "File Management",
     request_body(content = FileDownloadRequest, description = "Optional custom filename for download", content_type = "application/json"),
     responses(
-        (status = 200, description = "File found", body = Vec<u8>, content_type = "application/octet-stream"),
+        (status = 200, description = "File found", body = [u8], content_type = "application/octet-stream"),
         (status = 404, description = "File not found", body = ResponseError),
         (status = 500, description = "Internal server error", body = ResponseError),
     ),

--- a/src/server/file_handlers.rs
+++ b/src/server/file_handlers.rs
@@ -33,7 +33,7 @@ pub struct FileUploadResponse {
     tag = "File Management",
     request_body(content = Vec<u8>, description = "File data to upload", content_type = "application/octet-stream"),
     responses(
-        (status = 201, description = "File uploaded successfully", body = ResponseResult),
+        (status = 201, description = "File uploaded successfully", body = FileUploadResponse),
         (status = 400, description = "Bad request", body = ResponseError),
         (status = 500, description = "Internal server error", body = ResponseError),
     ),
@@ -116,7 +116,7 @@ pub struct FileDownloadRequest {
 /// Retrieve a file by its hash from path, with optional custom filename in request body.
 /// The file will be reconstructed from its blocks.
 #[utoipa::path(
-    post,
+    get,
     path = "/api/v1/file/{hash}",
     tag = "File Management",
     request_body(content = FileDownloadRequest, description = "Optional custom filename for download", content_type = "application/json"),

--- a/src/server/file_handlers.rs
+++ b/src/server/file_handlers.rs
@@ -10,19 +10,11 @@ use crate::server::{
     response::{ResponseError, ResponseResult},
 };
 use serde::{Deserialize, Serialize};
-use utoipa::{OpenApi, ToSchema};
+use utoipa::ToSchema;
 
 const BLOCK_SIZE: usize = 1024 * 1024; // 1MB
 
-#[derive(OpenApi)]
-#[openapi(
-    paths(upload_file_handler, get_file_handler),
-    components(schemas(File, FileUploadResponse, FileDownloadRequest)),
-    tags(
-        (name = "files", description = "File management API")
-    )
-)]
-pub struct FileApi;
+// File API endpoints are included in the main FlistApi in handlers.rs
 
 /// Response for file upload
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
@@ -38,11 +30,12 @@ pub struct FileUploadResponse {
 #[utoipa::path(
     post,
     path = "/api/v1/file",
+    tag = "File Management",
     request_body(content = Vec<u8>, description = "File data to upload", content_type = "application/octet-stream"),
     responses(
-        (status = 201, description = "File uploaded successfully", body = FileUploadResponse),
-        (status = 400, description = "Bad request"),
-        (status = 500, description = "Internal server error"),
+        (status = 201, description = "File uploaded successfully", body = ResponseResult),
+        (status = 400, description = "Bad request", body = ResponseError),
+        (status = 500, description = "Internal server error", body = ResponseError),
     )
 )]
 #[debug_handler]
@@ -122,11 +115,12 @@ pub struct FileDownloadRequest {
 #[utoipa::path(
     post,
     path = "/api/v1/file/{hash}",
+    tag = "File Management",
     request_body(content = FileDownloadRequest, description = "Optional custom filename for download", content_type = "application/json"),
     responses(
-        (status = 200, description = "File found", content_type = "application/octet-stream"),
-        (status = 404, description = "File not found"),
-        (status = 500, description = "Internal server error"),
+        (status = 200, description = "File found", body = Vec<u8>, content_type = "application/octet-stream"),
+        (status = 404, description = "File not found", body = ResponseError),
+        (status = 500, description = "Internal server error", body = ResponseError),
     ),
     params(
         ("hash" = String, Path, description = "File hash")

--- a/src/server/file_handlers.rs
+++ b/src/server/file_handlers.rs
@@ -36,6 +36,9 @@ pub struct FileUploadResponse {
         (status = 201, description = "File uploaded successfully", body = ResponseResult),
         (status = 400, description = "Bad request", body = ResponseError),
         (status = 500, description = "Internal server error", body = ResponseError),
+    ),
+    security(
+        ("bearerAuth" = [])
     )
 )]
 #[debug_handler]

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -102,10 +102,15 @@ pub struct PreviewResponse {
 
 #[derive(Debug, Clone, Serialize, PartialEq, ToSchema)]
 pub enum FlistState {
+    #[schema(title = "FlistStateAccepted")]
     Accepted(String),
+    #[schema(title = "FlistStateStarted")]
     Started(String),
+    #[schema(title = "FlistStateInProgress")]
     InProgress(FlistStateInfo),
+    #[schema(title = "FlistStateCreated")]
     Created(String),
+    #[schema(title = "FlistStateFailed")]
     Failed,
 }
 

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -64,7 +64,7 @@ impl Modify for SecurityAddon {
             // Block schemas
             block_handlers::VerifyBlock, block_handlers::VerifyBlocksRequest, block_handlers::VerifyBlocksResponse,
             block_handlers::BlocksResponse, block_handlers::ListBlocksParams, block_handlers::ListBlocksResponse, block_handlers::BlockInfo,
-            block_handlers::UserBlocksResponse, block_handlers::BlockDownloadsResponse, block_handlers::UploadBlockParams,
+            block_handlers::UserBlocksResponse, block_handlers::BlockDownloadsResponse, block_handlers::UploadBlockParams, block_handlers::UserBlockInfo,
             // File schemas
             file_handlers::FileUploadResponse, file_handlers::FileDownloadRequest
         )

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -22,7 +22,7 @@ use crate::server::{
     config::{self, Job},
     db::DB,
     response::{DirListTemplate, DirLister, ErrorTemplate, TemplateErr},
-    response::{FileInfo, ResponseError, ResponseResult},
+    response::{FileInfo, ResponseError, ResponseResult, FlistStateResponse},
     serve_flists::visit_dir_one_level,
 };
 use crate::store;
@@ -54,7 +54,7 @@ impl Modify for SecurityAddon {
     components(
         schemas(
             // Common schemas
-            DirListTemplate, DirLister, ResponseError, ErrorTemplate, TemplateErr, ResponseResult, FileInfo,
+            DirListTemplate, DirLister, ResponseError, ErrorTemplate, TemplateErr, ResponseResult, FileInfo, FlistStateResponse,
             // Authentication schemas
             SignInBody, SignInResponse,
             // Flist schemas
@@ -321,7 +321,7 @@ pub async fn create_flist_handler(
     path = "/api/v1/fl/{job_id}",
     tag = "Flist Management",
     responses(
-        (status = 200, description = "Flist state", body = FlistState),
+        (status = 200, description = "Flist state", body = FlistStateResponse),
         (status = 404, description = "Flist not found", body = ResponseError),
         (status = 500, description = "Internal server error", body = ResponseError),
         (status = 401, description = "Unauthorized user", body = ResponseError),

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -22,7 +22,7 @@ use crate::server::{
     config::{self, Job},
     db::DB,
     response::{DirListTemplate, DirLister, ErrorTemplate, TemplateErr},
-    response::{FileInfo, ResponseError, ResponseResult, FlistStateResponse},
+    response::{FileInfo, ResponseError, ResponseResult, FlistStateResponse, HealthResponse, BlockUploadedResponse},
     serve_flists::visit_dir_one_level,
 };
 use crate::store;
@@ -56,24 +56,23 @@ impl Modify for SecurityAddon {
             // Common schemas
             DirListTemplate, DirLister, ResponseError, ErrorTemplate, TemplateErr, ResponseResult, FileInfo, FlistStateResponse,
             // Response wrapper schemas
-            crate::server::response::HealthResponse, crate::server::response::BlockUploadedResponse,
+            HealthResponse, BlockUploadedResponse,
             // Authentication schemas
             SignInBody, SignInResponse,
             // Flist schemas
             FlistBody, Job, FlistState, FlistStateInfo, PreviewResponse,
             // Block schemas
-            crate::server::models::Block, block_handlers::VerifyBlock, block_handlers::VerifyBlocksRequest, block_handlers::VerifyBlocksResponse,
+            block_handlers::VerifyBlock, block_handlers::VerifyBlocksRequest, block_handlers::VerifyBlocksResponse,
             block_handlers::BlocksResponse, block_handlers::ListBlocksParams, block_handlers::ListBlocksResponse, block_handlers::BlockInfo,
             block_handlers::UserBlocksResponse, block_handlers::BlockDownloadsResponse, block_handlers::UploadBlockParams,
             // File schemas
-            file_handlers::FileUploadResponse, file_handlers::FileDownloadRequest, crate::server::models::File
+            file_handlers::FileUploadResponse, file_handlers::FileDownloadRequest
         )
     ),
     tags(
         (name = "System", description = "System health and status"),
         (name = "Authentication", description = "Authentication endpoints"),
         (name = "Flist Management", description = "Flist creation and management"),
-        (name = "Flist Serving", description = "Serving flist files"),
         (name = "Block Management", description = "Block storage and retrieval"),
         (name = "File Management", description = "File upload and download"),
         (name = "Website Serving", description = "Website content serving")

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -55,13 +55,15 @@ impl Modify for SecurityAddon {
         schemas(
             // Common schemas
             DirListTemplate, DirLister, ResponseError, ErrorTemplate, TemplateErr, ResponseResult, FileInfo, FlistStateResponse,
+            // Response wrapper schemas
+            crate::server::response::HealthResponse, crate::server::response::BlockUploadedResponse,
             // Authentication schemas
             SignInBody, SignInResponse,
             // Flist schemas
             FlistBody, Job, FlistState, FlistStateInfo, PreviewResponse,
             // Block schemas
             crate::server::models::Block, block_handlers::VerifyBlock, block_handlers::VerifyBlocksRequest, block_handlers::VerifyBlocksResponse,
-            block_handlers::BlocksResponse, block_handlers::ListBlocksParams, block_handlers::ListBlocksResponse,
+            block_handlers::BlocksResponse, block_handlers::ListBlocksParams, block_handlers::ListBlocksResponse, block_handlers::BlockInfo,
             block_handlers::UserBlocksResponse, block_handlers::BlockDownloadsResponse, block_handlers::UploadBlockParams,
             // File schemas
             file_handlers::FileUploadResponse, file_handlers::FileDownloadRequest, crate::server::models::File
@@ -125,7 +127,7 @@ pub struct FlistStateInfo {
     path = "/api/v1",
     tag = "System",
     responses(
-        (status = 200, description = "flist server is working", body = String)
+        (status = 200, description = "flist server is working", body = HealthResponse)
     )
 )]
 pub async fn health_check_handler() -> ResponseResult {

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -28,13 +28,38 @@ use crate::server::{
 use crate::store;
 use utoipa::{OpenApi, ToSchema};
 use uuid::Uuid;
+use crate::server::block_handlers;
+use crate::server::file_handlers;
+use crate::server::serve_flists;
+use crate::server::website_handlers;
 
 #[derive(OpenApi)]
 #[openapi(
-    paths(health_check_handler, create_flist_handler, get_flist_state_handler, preview_flist_handler, list_flists_handler, sign_in_handler),
-    components(schemas(DirListTemplate, DirLister, FlistBody, Job, ResponseError, ErrorTemplate, TemplateErr, ResponseResult, FileInfo, SignInBody, FlistState, SignInResponse, FlistStateInfo, PreviewResponse)),
+    paths(health_check_handler, create_flist_handler, get_flist_state_handler, preview_flist_handler, list_flists_handler, sign_in_handler, block_handlers::upload_block_handler, block_handlers::get_block_handler, block_handlers::check_block_handler, block_handlers::verify_blocks_handler, block_handlers::get_blocks_by_hash_handler, block_handlers::list_blocks_handler, block_handlers::get_block_downloads_handler, block_handlers::get_user_blocks_handler, file_handlers::upload_file_handler, file_handlers::get_file_handler, website_handlers::serve_website_handler, serve_flists::serve_flists),
+    components(
+        schemas(
+            // Common schemas
+            DirListTemplate, DirLister, ResponseError, ErrorTemplate, TemplateErr, ResponseResult, FileInfo,
+            // Authentication schemas
+            SignInBody, SignInResponse,
+            // Flist schemas
+            FlistBody, Job, FlistState, FlistStateInfo, PreviewResponse,
+            // Block schemas
+            crate::server::models::Block, block_handlers::VerifyBlock, block_handlers::VerifyBlocksRequest, block_handlers::VerifyBlocksResponse,
+            block_handlers::BlocksResponse, block_handlers::ListBlocksParams, block_handlers::ListBlocksResponse,
+            block_handlers::UserBlocksResponse, block_handlers::BlockDownloadsResponse, block_handlers::UploadBlockParams,
+            // File schemas
+            file_handlers::FileUploadResponse, file_handlers::FileDownloadRequest, crate::server::models::File
+        )
+    ),
     tags(
-        (name = "fl-server", description = "Flist conversion API")
+        (name = "System", description = "System health and status"),
+        (name = "Authentication", description = "Authentication endpoints"),
+        (name = "Flist Management", description = "Flist creation and management"),
+        (name = "Flist Serving", description = "Serving flist files"),
+        (name = "Block Management", description = "Block storage and retrieval"),
+        (name = "File Management", description = "File upload and download"),
+        (name = "Website Serving", description = "Website content serving")
     )
 )]
 pub struct FlistApi;
@@ -55,7 +80,7 @@ pub struct FlistBody {
 
 #[derive(Debug, Deserialize, Serialize, Clone, ToSchema)]
 pub struct PreviewResponse {
-    pub content: Vec<PathBuf>,
+    pub content: Vec<String>,
     pub metadata: String,
     pub checksum: String,
 }
@@ -77,7 +102,8 @@ pub struct FlistStateInfo {
 
 #[utoipa::path(
     get,
-    path = "/v1/api",
+    path = "/api/v1",
+    tag = "System",
     responses(
         (status = 200, description = "flist server is working", body = String)
     )
@@ -88,14 +114,15 @@ pub async fn health_check_handler() -> ResponseResult {
 
 #[utoipa::path(
     post,
-    path = "/v1/api/fl",
+    path = "/api/v1/fl",
+    tag = "Flist Management",
     request_body = FlistBody,
     responses(
         (status = 201, description = "Flist conversion started", body = Job),
-        (status = 401, description = "Unauthorized user"),
-        (status = 403, description = "Forbidden"),
-        (status = 409, description = "Conflict"),
-        (status = 500, description = "Internal server error"),
+        (status = 401, description = "Unauthorized user", body = ResponseError),
+        (status = 403, description = "Forbidden", body = ResponseError),
+        (status = 409, description = "Conflict", body = ResponseError),
+        (status = 500, description = "Internal server error", body = ResponseError),
     )
 )]
 #[debug_handler]
@@ -268,13 +295,14 @@ pub async fn create_flist_handler(
 
 #[utoipa::path(
     get,
-    path = "/v1/api/fl/{job_id}",
+    path = "/api/v1/fl/{job_id}",
+    tag = "Flist Management",
     responses(
         (status = 200, description = "Flist state", body = FlistState),
-        (status = 404, description = "Flist not found"),
-        (status = 500, description = "Internal server error"),
-        (status = 401, description = "Unauthorized user"),
-        (status = 403, description = "Forbidden"),
+        (status = 404, description = "Flist not found", body = ResponseError),
+        (status = 500, description = "Internal server error", body = ResponseError),
+        (status = 401, description = "Unauthorized user", body = ResponseError),
+        (status = 403, description = "Forbidden", body = ResponseError),
     ),
     params(
         ("job_id" = String, Path, description = "flist job id")
@@ -329,12 +357,13 @@ pub async fn get_flist_state_handler(
 
 #[utoipa::path(
 	get,
-	path = "/v1/api/fl",
+	path = "/api/v1/fl",
+	tag = "Flist Management",
 	responses(
         (status = 200, description = "Listing flists", body = HashMap<String, Vec<FileInfo>>),
-        (status = 401, description = "Unauthorized user"),
-        (status = 403, description = "Forbidden"),
-        (status = 500, description = "Internal server error"),
+        (status = 401, description = "Unauthorized user", body = ResponseError),
+        (status = 403, description = "Forbidden", body = ResponseError),
+        (status = 500, description = "Internal server error", body = ResponseError),
 	)
 )]
 #[debug_handler]
@@ -370,13 +399,14 @@ pub async fn list_flists_handler(State(state): State<Arc<config::AppState>>) -> 
 
 #[utoipa::path(
 	get,
-	path = "/v1/api/fl/preview/{flist_path}",
+	path = "/api/v1/fl/preview/{flist_path}",
+	tag = "Flist Management",
 	responses(
         (status = 200, description = "Flist preview result", body = PreviewResponse),
-        (status = 400, description = "Bad request"),
-        (status = 401, description = "Unauthorized user"),
-        (status = 403, description = "Forbidden"),
-        (status = 500, description = "Internal server error"),
+        (status = 400, description = "Bad request", body = ResponseError),
+        (status = 401, description = "Unauthorized user", body = ResponseError),
+        (status = 403, description = "Forbidden", body = ResponseError),
+        (status = 500, description = "Internal server error", body = ResponseError),
 	),
     params(
         ("flist_path" = String, Path, description = "flist file path")
@@ -411,8 +441,14 @@ pub async fn preview_flist_handler(
         }
     };
 
+    // Convert PathBuf values to strings for OpenAPI compatibility
+    let content_strings: Vec<String> = content
+        .into_iter()
+        .map(|path| path.to_string_lossy().to_string())
+        .collect();
+        
     Ok(ResponseResult::PreviewFlist(PreviewResponse {
-        content,
+        content: content_strings,
         metadata: state.config.store_url.join("-"),
         checksum: sha256::digest(&bytes),
     }))

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -35,11 +35,9 @@ use tower::ServiceBuilder;
 use tower_http::cors::CorsLayer;
 use tower_http::{cors::Any, trace::TraceLayer};
 
-use block_handlers::BlockApi;
-use file_handlers::FileApi;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
-use website_handlers::WebsiteApi;
+// Using only the main FlistApi for OpenAPI documentation
 
 pub async fn app(config_path: &str) -> Result<()> {
     let config = config::parse_config(config_path)
@@ -154,10 +152,7 @@ pub async fn app(config_path: &str) -> Result<()> {
     let app = Router::new()
         .merge(
             SwaggerUi::new("/swagger-ui")
-                .url("/api-docs/openapi.json", handlers::FlistApi::openapi())
-                .url("/api-docs/block-api.json", BlockApi::openapi())
-                .url("/api-docs/file-api.json", FileApi::openapi())
-                .url("/api-docs/website-api.json", WebsiteApi::openapi()),
+                .url("/api-docs/openapi.json", handlers::FlistApi::openapi()),
         )
         .merge(v1_routes)
         .layer(

--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -81,6 +81,13 @@ impl IntoResponse for ResponseError {
     }
 }
 
+// Wrapper structs for OpenAPI documentation to match the actual JSON response format
+#[derive(Serialize, ToSchema)]
+pub struct FlistStateResponse {
+    pub flist_state: FlistState,
+}
+
+
 #[derive(Serialize,ToSchema)]
 pub enum ResponseResult {
     #[schema(title = "ResponseResultHealth")]

--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -19,12 +19,19 @@ use crate::server::{
 
 #[derive(Serialize, ToSchema)]
 pub enum ResponseError {
+    #[schema(title = "ResponseErrorInternalServerError")]
     InternalServerError,
+    #[schema(title = "ResponseErrorConflict")]
     Conflict(String),
+    #[schema(title = "ResponseErrorNotFound")]
     NotFound(String),
+    #[schema(title = "ResponseErrorUnauthorized")]
     Unauthorized(String),
+    #[schema(title = "ResponseErrorBadRequest")]
     BadRequest(String),
+    #[schema(title = "ResponseErrorForbidden")]
     Forbidden(String),
+    #[schema(title = "ResponseErrorTemplateError")]
     TemplateError(ErrorTemplate),
 }
 
@@ -74,18 +81,28 @@ impl IntoResponse for ResponseError {
     }
 }
 
-#[derive(ToSchema)]
+#[derive(Serialize,ToSchema)]
 pub enum ResponseResult {
+    #[schema(title = "ResponseResultHealth")]
     Health,
+    #[schema(title = "ResponseResultFlistCreated")]
     FlistCreated(Job),
+    #[schema(title = "ResponseResultFlistState")]
     FlistState(FlistState),
+    #[schema(title = "ResponseResultFlists")]
     Flists(HashMap<String, Vec<FileInfo>>),
+    #[schema(title = "ResponseResultPreviewFlist")]
     PreviewFlist(PreviewResponse),
+    #[schema(title = "ResponseResultSignedIn")]
     SignedIn(SignInResponse),
+    #[schema(title = "ResponseResultDirTemplate")]
     DirTemplate(DirListTemplate),
+    #[schema(title = "ResponseResultBlockUploaded")]
     BlockUploaded(String),
+    #[schema(title = "ResponseResultFileUploaded")]
     FileUploaded(FileUploadResponse),
-    #[schema(value_type = Vec<u8>)]
+    #[schema(value_type = Vec<u8>, title = "ResponseResultRes")]
+    #[serde(skip_serializing)]
     Res(hyper::Response<tower_http::services::fs::ServeFileSystemResponseBody>),
 }
 
@@ -187,7 +204,10 @@ const FAIL_REASON_HEADER_NAME: &str = "fl-server-fail-reason";
 
 #[derive(Serialize, ToSchema)]
 pub enum TemplateErr {
+    #[schema(title = "TemplateErrBadRequest")]
     BadRequest(String),
+    #[schema(title = "TemplateErrNotFound")]
     NotFound(String),
+    #[schema(title = "TemplateErrInternalServerError")]
     InternalServerError(String),
 }

--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -85,6 +85,7 @@ pub enum ResponseResult {
     DirTemplate(DirListTemplate),
     BlockUploaded(String),
     FileUploaded(FileUploadResponse),
+    #[schema(value_type = Vec<u8>)]
     Res(hyper::Response<tower_http::services::fs::ServeFileSystemResponseBody>),
 }
 

--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -87,6 +87,17 @@ pub struct FlistStateResponse {
     pub flist_state: FlistState,
 }
 
+#[derive(Serialize, ToSchema)]
+pub struct HealthResponse {
+    pub msg: String,
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct BlockUploadedResponse {
+    pub hash: String,
+    pub message: String,
+}
+
 
 #[derive(Serialize,ToSchema)]
 pub enum ResponseResult {
@@ -118,7 +129,9 @@ impl IntoResponse for ResponseResult {
         match self {
             ResponseResult::Health => (
                 StatusCode::OK,
-                Json(serde_json::json!({"msg": "flist server is working"})),
+                Json(HealthResponse {
+                    msg: "flist server is working".to_string(),
+                }),
             )
                 .into_response(),
             ResponseResult::SignedIn(token) => (StatusCode::CREATED, Json(token)).into_response(),
@@ -136,10 +149,10 @@ impl IntoResponse for ResponseResult {
             }
             ResponseResult::BlockUploaded(hash) => (
                 StatusCode::OK,
-                Json(serde_json::json!({
-                    "hash": hash,
-                    "message": "Block processed successfully"
-                })),
+                Json(BlockUploadedResponse {
+                    hash,
+                    message: "Block processed successfully".to_string(),
+                }),
             )
                 .into_response(),
             ResponseResult::FileUploaded(response) => {

--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -99,7 +99,7 @@ pub struct BlockUploadedResponse {
 }
 
 
-#[derive(Serialize,ToSchema)]
+#[derive(ToSchema)]
 pub enum ResponseResult {
     #[schema(title = "ResponseResultHealth")]
     Health,
@@ -119,8 +119,7 @@ pub enum ResponseResult {
     BlockUploaded(String),
     #[schema(title = "ResponseResultFileUploaded")]
     FileUploaded(FileUploadResponse),
-    #[schema(value_type = Vec<u8>, title = "ResponseResultRes")]
-    #[serde(skip_serializing)]
+    #[schema(value_type = String, title = "ResponseResultRes", format = "binary")]
     Res(hyper::Response<tower_http::services::fs::ServeFileSystemResponseBody>),
 }
 

--- a/src/server/serve_flists.rs
+++ b/src/server/serve_flists.rs
@@ -25,7 +25,7 @@ use crate::server::{
 #[utoipa::path(
     get,
     path = "/{path}",
-    tag = "Flist Serving",
+    tag = "Flist Management",
     params(
         ("path" = String, Path, description = "Path to the flist file or directory to serve")
     ),

--- a/src/server/serve_flists.rs
+++ b/src/server/serve_flists.rs
@@ -21,6 +21,20 @@ use crate::server::{
 };
 
 #[debug_handler]
+/// Serve flist files from the server's filesystem
+#[utoipa::path(
+    get,
+    path = "/{path}",
+    tag = "Flist Serving",
+    params(
+        ("path" = String, Path, description = "Path to the flist file or directory to serve")
+    ),
+    responses(
+        (status = 200, description = "Successfully served the flist or directory listing", body = ResponseResult),
+        (status = 404, description = "Flist not found", body = ResponseError),
+        (status = 500, description = "Internal server error", body = ResponseError)
+    )
+)]
 pub async fn serve_flists(
     State(state): State<Arc<config::AppState>>,
     req: Request<Body>,

--- a/src/server/website_handlers.rs
+++ b/src/server/website_handlers.rs
@@ -116,7 +116,7 @@ async fn decrypt_block(state: &Arc<AppState>, block: &meta::Block) -> Result<Vec
     path = "/api/v1/website/{website_hash}/{path}",
     tag = "Website Serving",
     responses(
-        (status = 200, description = "Website file served successfully", content_type = "application/octet-stream", body = Vec<u8>),
+        (status = 200, description = "Website file served successfully", content_type = "application/octet-stream", body = [u8]),
         (status = 404, description = "File not found", body = ResponseError),
         (status = 500, description = "Internal server error", body = ResponseError),
     ),

--- a/src/server/website_handlers.rs
+++ b/src/server/website_handlers.rs
@@ -14,18 +14,11 @@ use mime_guess::from_path;
 use std::fs;
 use std::sync::Arc;
 use tempfile::NamedTempFile;
-use utoipa::OpenApi;
+// OpenApi is now only used in the main handlers.rs file
 
 use crate::server::{config::AppState, db::DB, response::ResponseError};
 
-#[derive(OpenApi)]
-#[openapi(
-    paths(serve_website_handler),
-    tags(
-        (name = "websites", description = "Website serving API")
-    )
-)]
-pub struct WebsiteApi;
+// Website API endpoints are included in the main FlistApi in handlers.rs
 
 /// Resolves a file path within a flist database to get file information
 async fn get_file_from_flist(flist_content: &[u8], file_path: &str) -> Result<Vec<meta::Block>> {
@@ -120,11 +113,12 @@ async fn decrypt_block(state: &Arc<AppState>, block: &meta::Block) -> Result<Vec
 
 #[utoipa::path(
     get,
-    path = "/v1/api/website/{website_hash}/{path:.*}",
+    path = "/api/v1/website/{website_hash}/{path:.*}",
+    tag = "Website Serving",
     responses(
-        (status = 200, description = "Website file served successfully"),
-        (status = 404, description = "File not found"),
-        (status = 500, description = "Internal server error"),
+        (status = 200, description = "Website file served successfully", content_type = "application/octet-stream", body = Vec<u8>),
+        (status = 404, description = "File not found", body = ResponseError),
+        (status = 500, description = "Internal server error", body = ResponseError),
     ),
     params(
         ("website_hash" = String, Path, description = "flist hash of the website directory"),

--- a/src/server/website_handlers.rs
+++ b/src/server/website_handlers.rs
@@ -113,7 +113,7 @@ async fn decrypt_block(state: &Arc<AppState>, block: &meta::Block) -> Result<Vec
 
 #[utoipa::path(
     get,
-    path = "/api/v1/website/{website_hash}/{path:.*}",
+    path = "/api/v1/website/{website_hash}/{path}",
     tag = "Website Serving",
     responses(
         (status = 200, description = "Website file served successfully", content_type = "application/octet-stream", body = Vec<u8>),


### PR DESCRIPTION
## Changes
- Consolidate API definitions into a single FlistApi struct
- Add logical grouping of endpoints with tags
- Fix schema references and serialization issues
- Make response types OpenAPI-compatible
- Fix endpoint method inconsistencies and documentation
- Add the missing endpoints

## Benefits
- Better organized and more accurate API documentation
- Fix client code generation from OpenAPI specs
- Swagger-ui now includes all endpoints with correct type definitions