### PR TITLE
Fix clashes with Clap’s auto-generated `-h`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -101,7 +101,7 @@ struct FlistInspectionOptions {
 #[derive(Args, Debug)]
 struct SyncOptions {
     /// Hash of the file or block to sync
-    #[clap(short, long)]
+    #[clap(short = 'H', long)]
     hash: Option<String>,
 
     /// Source server URL (e.g., http://localhost:8080)
@@ -479,7 +479,7 @@ struct TrackBlocksOptions {
     token: String,
 
     /// specific block hash to track
-    #[clap(short, long, conflicts_with = "all")]
+    #[clap(short = 'H', long, conflicts_with = "all")]
     hash: Option<String>,
 
     /// track all blocks (default if no hash is provided)


### PR DESCRIPTION
This fixed the thread panic when the rfs binary used with sync commandThis resolved the thread panic that occurred when the rfs binary was used with the sync command. The issue arose from the SyncOptions.hash flag, which used the short option `-h`, conflicting with Clap's automatically generated `-h`/`--help` flag. The conflict was fixed by changing the short flag for hash from `-h` to `-H`.

- `SyncOptions`
- `TrackBlocksOptions`

Related issues:
- https://github.com/threefoldtech/rfs/issues/123