### PR TITLE
fs: prefer fusermount3; add nonempty when using fusermount (FUSE2)

### DIFF
--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -79,12 +79,27 @@ where
             std::process::id()
         ));
 
+        // Prefer fusermount3 if available (FUSE3), otherwise fall back to fusermount (FUSE2).
         // polyfuse assumes an absolute path, see https://github.com/ubnt-intrepid/polyfuse/issues/83
-        let fusermount_path =
-            which::which("fusermount").context("looking up 'fusermount' in PATH")?;
-        options.fusermount_path(fusermount_path);
+        let fusermount_path = which::which("fusermount3")
+            .or_else(|_| which::which("fusermount"))
+            .context("looking up 'fusermount3' or 'fusermount' in PATH")?;
+        // Clone because we need to both set the path and inspect the filename.
+        options.fusermount_path(fusermount_path.clone());
+
+        // 'nonempty' is specific to libfuse2 and may be rejected by fusermount3.
+        // Only add it when using the legacy 'fusermount' binary.
+        let is_fuse2 = fusermount_path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(|n| n == "fusermount")
+            .unwrap_or(false);
+        if is_fuse2 {
+            options.mount_option("nonempty");
+        }
 
         let session = AsyncSession::mount(mountpoint, options).await?;
+
 
         // release here
         while let Some(req) = session.next_request().await? {


### PR DESCRIPTION
Summary:
- Prefer fusermount3 when available; fallback to fusermount.
- Pass nonempty only when using legacy fusermount (FUSE2) to allow mounting over non-empty directories.

Key changes:
- Mount options baseline (without nonempty): [src/fs/mod.rs:76](src/fs/mod.rs:76)
- Prefer fusermount3, fallback to fusermount, using absolute path per polyfuse: [src/fs/mod.rs:82](src/fs/mod.rs:82)
- Clone path before inspection: [src/fs/mod.rs:86](src/fs/mod.rs:86)
- Conditionally add nonempty only for fusermount (FUSE2): [src/fs/mod.rs:91](src/fs/mod.rs:91)

Build:
- Verified with MUSL target debug build using feature flag:
  cargo build --target x86_64-unknown-linux-musl --features build-binary

Context:
- Addresses mounting over non-empty directories while maintaining FUSE3 compatibility (nonempty omitted for fusermount3).
